### PR TITLE
Update CI/CD workflows pt2

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,3 +13,8 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     uses: ./.github/workflows/ci.yaml
+  security:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    uses: ./.github/workflows/security.yaml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,7 +14,4 @@ jobs:
       cancel-in-progress: true
     uses: ./.github/workflows/ci.yaml
   security:
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     uses: ./.github/workflows/security.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,32 +17,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-          cache-dependency-path: go.sum
-      - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
-        with:
-          version: v2.4.0
-          args: --verbose --timeout=3m
-  tests:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-          cache-dependency-path: go.sum
-      - name: Run tests
-        run: go test ./... -timeout 60s -race
+  ci:
+    uses: ./.github/workflows/ci.yaml
   release:
-    needs: [lint, tests]
+    needs: [ci]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
         with:
-          cache-dependency-path: go.sum
+          go-version-input: '1.24.2'
           output-format: sarif
           output-file: govulncheck.sarif
       - name: Upload static analysis result

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -2,6 +2,9 @@ name: GO Security Check
 
 on:
   workflow_call:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * *' # Every night midnight UTC
 
 jobs:
   check-for-vulnerabilities:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -7,7 +7,6 @@ jobs:
   check-for-vulnerabilities:
     runs-on: ubuntu-24.04
     permissions:
-      security-events: write
       contents: read
     steps:
       - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,23 @@
+name: GO Security Check
+
+on:
+  workflow_call:
+
+jobs:
+  check-for-vulnerabilities:
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
+        with:
+          cache-dependency-path: go.sum
+          output-format: sarif
+          output-file: govulncheck.sarif
+      - name: Upload static analysis result
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: govulncheck-${{ github.run_number }}
+          path: govulncheck.sarif
+          retention-days: 1

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -9,12 +9,18 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
-          go-version-input: '1.24.2'
-          output-format: sarif
-          output-file: govulncheck.sarif
-      - name: Upload static analysis result
+          go-version-file: 'go.mod'
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        shell: bash
+      - name: Run govulncheck
+        run: govulncheck -C . -format sarif ./... > govulncheck.sarif
+      - name: Upload govulncheck result
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: govulncheck-${{ github.run_number }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,7 @@ linters:
     - paralleltest
     - thelper
     - tparallel
+    - gosec
 formatters:
   enable:
     - gofmt

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ GO_COVERAGE_TEXT_FILE := $(BUILD_DIR)/cover.txt
 GO_COVERAGE_HTML_FILE := $(BUILD_DIR)/cover.html
 GOLANGCI_CMD := go tool golangci-lint
 GOLANGCI_ARGS ?= --fix --concurrency=4
+GOVULN_CMD := go tool govulncheck
 
 .PHONY: help
 help:
@@ -49,6 +50,7 @@ test/cover:
 .PHONY: lint
 lint:
 	@$(GO_CMD) vet ${GO_PKGS}
+	@$(GOVULN_CMD) 
 	@${GOLANGCI_CMD} run ${GOLANGCI_ARGS} ${GO_PKGS}
 
 ## audit: format, vet, and lint Go code

--- a/cmd/vaultfile/root.go
+++ b/cmd/vaultfile/root.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"github.com/HallyG/vaultfile/internal/vault"
 	"github.com/spf13/cobra"
@@ -169,6 +170,8 @@ func decrypt(ctx context.Context, v *vault.Vault, input []byte, password []byte,
 }
 
 func readInput(path string) ([]byte, error) {
+	path = filepath.Clean(path)
+
 	if path == "" {
 		return nil, fmt.Errorf("input file is required")
 	}
@@ -177,6 +180,8 @@ func readInput(path string) ([]byte, error) {
 }
 
 func openOutput(path string, force bool) (io.Writer, func() error, error) {
+	path = filepath.Clean(path)
+
 	if path == "" {
 		return os.Stdout, func() error { return nil }, nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -198,8 +198,10 @@ require (
 	golang.org/x/mod v0.25.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
+	golang.org/x/telemetry v0.0.0-20240522233618-39ace7a40ae7 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/tools v0.34.0 // indirect
+	golang.org/x/vuln v1.1.4 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
@@ -209,4 +211,7 @@ require (
 	mvdan.cc/unparam v0.0.0-20250301125049-0df0534333a4 // indirect
 )
 
-tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+tool (
+	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+	golang.org/x/vuln/cmd/govulncheck
+)

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e h1:gD6P7NEo7Eqt
 github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e/go.mod h1:h+wZwLjUTJnm/P2rwlbJdRPZXOzaT36/FwnPnY2inzc=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/go-cmdtest v0.4.1-0.20220921163831-55ab3332a786 h1:rcv+Ippz6RAtvaGgKxc+8FQIpxHgsF+HBzPyYL2cyVU=
+github.com/google/go-cmdtest v0.4.1-0.20220921163831-55ab3332a786/go.mod h1:apVn/GCasLZUVpAJ6oWAuyP7Ne7CEsQbTnc0plM3m+o=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -295,6 +297,7 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/ZoQgRgVIWFJljSWa/zetS2WTvg=
 github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
+github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -808,6 +811,8 @@ golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
 golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/telemetry v0.0.0-20240522233618-39ace7a40ae7 h1:FemxDzfMUcK2f3YY4H+05K9CDzbSVr2+q/JKN45pey0=
+golang.org/x/telemetry v0.0.0-20240522233618-39ace7a40ae7/go.mod h1:pRgIJT+bRLFKnoM1ldnzKoxTIn14Yxz928LQRYYgIN0=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
@@ -893,6 +898,8 @@ golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58
 golang.org/x/tools v0.14.0/go.mod h1:uYBEerGOWcJyEORxN+Ek8+TT266gXkNlHdJBwexUsBg=
 golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
 golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=
+golang.org/x/vuln v1.1.4 h1:Ju8QsuyhX3Hk8ma3CesTbO8vfJD9EvUBgHvkxHBzj0I=
+golang.org/x/vuln v1.1.4/go.mod h1:F+45wmU18ym/ca5PLTPLsSzr2KppzswxPP603ldA67s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/vault/format/format_test.go
+++ b/internal/vault/format/format_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"hash"
+	"math"
 	"testing"
 
 	"github.com/HallyG/vaultfile/internal/vault/format"
@@ -53,8 +54,12 @@ func TestReadCipherText(t *testing.T) {
 		t.Parallel()
 
 		cipherText := []byte("test ciphertext data")
+		length := format.TotalHeaderLen + len(cipherText)
+		require.LessOrEqual(t, length, math.MaxUint16)
+
 		header := &format.Header{
-			TotalPayloadLength: uint16(format.TotalHeaderLen + len(cipherText)),
+			// #nosec G115 - length is guaranteed to be < 65536
+			TotalPayloadLength: uint16(length),
 		}
 
 		result, err := format.ReadCipherText(bytes.NewReader(cipherText), header)

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -105,6 +105,12 @@ func (v *Vault) Encrypt(ctx context.Context, output io.Writer, password []byte, 
 
 	v.logger.Debug("encrypted plaintext", slog.Int("plaintext.size", len(plainText)), slog.Int("ciphertext.size", len(cipherText)))
 
+	length := len(cipherText)
+	if length > MaxCipherTextSize || length > math.MaxUint16 {
+		return fmt.Errorf("generated ciphertext exceeds maximum of %d bytes, got %d", MaxCipherTextSize, len(plainText))
+	}
+
+	// #nosec G115 - length is guaranteed to be < 65536
 	if err := format.EncodeHeader(
 		output,
 		hmac.New(sha256.New, hmacKey),

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
+	MaxCipherTextSize = math.MaxUint16 - format.TotalHeaderLen
 	// Assumes we are using [krypto.NewChaCha20Crypto] because XChaCha20-Poly1305 is a
 	// stream cipher (hence output=input bytes) with an additional 16 byte auth tag.
-	MaxCipherTextSize = math.MaxUint16 - 16 - format.TotalHeaderLen
+	MaxPlainTextSize = MaxCipherTextSize - 16
 )
 
 type Vault struct {
@@ -72,8 +73,8 @@ func (v *Vault) Encrypt(ctx context.Context, output io.Writer, password []byte, 
 		return errors.New("plaintext cannot be nil")
 	}
 
-	if len(plainText) > MaxCipherTextSize {
-		return fmt.Errorf("ciphertext exceeds maximum of %d bytes, got %d", MaxCipherTextSize, len(plainText))
+	if len(plainText) > MaxPlainTextSize {
+		return fmt.Errorf("plaintext exceeds maximum of %d bytes, got %d", MaxPlainTextSize, len(plainText))
 	}
 
 	salt, err := krypto.GenerateSalt(krypto.MinSaltLength)
@@ -107,7 +108,7 @@ func (v *Vault) Encrypt(ctx context.Context, output io.Writer, password []byte, 
 
 	length := len(cipherText)
 	if length > MaxCipherTextSize || length > math.MaxUint16 {
-		return fmt.Errorf("generated ciphertext exceeds maximum of %d bytes, got %d", MaxCipherTextSize, len(plainText))
+		return fmt.Errorf("ciphertext exceeds maximum of %d bytes, got %d", MaxCipherTextSize, len(plainText))
 	}
 
 	// #nosec G115 - length is guaranteed to be < 65536

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -94,14 +94,14 @@ func TestV1FormatEncrypt(t *testing.T) {
 		require.EqualError(t, err, "hmac key derivation failed: password length must be at least 1 characters, got 0")
 	})
 
-	t.Run("returns error when ciphertext too big", func(t *testing.T) {
+	t.Run("returns error when plaintext too big", func(t *testing.T) {
 		t.Parallel()
 
 		v, password := setupVault(t)
 
 		var buf bytes.Buffer
 		err := v.Encrypt(t.Context(), &buf, password, make([]byte, math.MaxUint16))
-		require.EqualError(t, err, "ciphertext exceeds maximum of 65431 bytes, got 65535")
+		require.EqualError(t, err, "plaintext exceeds maximum of 65431 bytes, got 65535")
 	})
 
 	t.Run("returns error when context cancellation", func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestV1FormatEncrypt(t *testing.T) {
 	t.Run("encrypt plaintext at maximum length", func(t *testing.T) {
 		t.Parallel()
 
-		plainText := make([]byte, vault.MaxCipherTextSize)
+		plainText := make([]byte, vault.MaxPlainTextSize)
 		v, password := setupVault(t)
 
 		var buf bytes.Buffer


### PR DESCRIPTION
- Add `govulncheck` to project toolchain
- Run `govulncheck` in CI/CD pipeline on each PR.
- Run `govulncheck` every midnight (UTC) on `main`.
- Add `gosec` to `golangci` linters and address overflow and file path issues.