### PR TITLE
Replace input file and output file CLI flags with `stdout` and `stdin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/github/license/hallyg/vaultfile)](https://github.com/HallyG/vaultfile/blob/master/LICENSE)
 ![Go Version](https://img.shields.io/github/go-mod/go-version/hallyg/vaultfile)
 
-A CLI for encrypting and decrypting file content using the experimental VaultFile format.
+A CLI for encrypting and decrypting content with a password using the experimental VaultFile format.
 
 ## Table of Contents
 - [Disclaimer](#disclaimer)
@@ -13,8 +13,8 @@ A CLI for encrypting and decrypting file content using the experimental VaultFil
   - [From Source](#from-source)
 - [Documentation](#documentation)
 - [Examples](#examples)
-  - [Encrypting a File](#encrypting-a-file)
-  - [Decrypting a File](#decrypting-a-file)
+  - [Encrypting Content](#encrypting-content)
+  - [Decrypting Content](#decrypting-content)
 - [License](#license)
 
 ## Disclaimer
@@ -48,43 +48,63 @@ Documentation about the `vaultfile` binary format can be found [here](./docs/vau
 
 Below are some basic usage examples. More can be found in the [examples directory](./examples).
 
-### Encrypting a File
+### Encrypting Content
 
-1. Create a sample plaintext file:
+1. Encrypt content from a file:
    ```bash
-   echo "hello-world" > plaintext.txt
-   ```
-
-2. Encrypt the file:
-   ```bash
-   vaultfile encrypt -i plaintext.txt -o encrypted.vault
-   ```
-   You will be prompted for a password:
-   ```bash
-   Enter password:
-   Confirm password:
-   ```
-3. The encrypted output (`encrypted.vault`) is a binary file.
-
-### Decrypting a File
-
-1. Decrypt the encrypted file back to plaintext:
-   ```bash
-   vaultfile decrypt -i encrypted.vault -o decrypted.txt
-   ```
-   You will be prompted for a password:
-   ```bash
-   Enter password:
-   Confirm password:
+   cat plaintext.txt | vaultfile encrypt > encrypted.vault
    ```
 
-2. Verify the contents:
+2. Encrypt text directly:
    ```bash
-   cat decrypted.txt
+   echo "hello-world" | vaultfile encrypt > encrypted.vault
    ```
+
+3. Encrypt using input redirection:
    ```bash
-   > hello-world
+   vaultfile encrypt < plaintext.txt > encrypted.vault
    ```
+
+You will be prompted for a password during encryption:
+```bash
+Enter password:
+Confirm password:
+```
+
+### Decrypting Content
+
+1. Decrypt to a file:
+   ```bash
+   cat encrypted.vault | vaultfile decrypt > decrypted.txt
+   ```
+
+2. Decrypt and display directly:
+   ```bash
+   cat encrypted.vault | vaultfile decrypt
+   ```
+
+3. Decrypt using input redirection:
+   ```bash
+   vaultfile decrypt < encrypted.vault > decrypted.txt
+   ```
+
+You will be prompted for a password during decryption:
+```bash
+Enter password:
+```
+
+### Chaining Operations
+
+```bash
+# Compress then encrypt
+tar czf - my-directory/ | vaultfile encrypt > backup.vault
+
+# Decrypt then extract
+cat backup.vault | vaultfile decrypt | tar xzf -
+
+# Encrypt data from a web request
+curl -s https://api.example.com/data.json | vaultfile encrypt > api-data.vault
+```
 
 ## License
 This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for details.

--- a/cmd/vaultfile/root.go
+++ b/cmd/vaultfile/root.go
@@ -3,12 +3,10 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 
 	"github.com/HallyG/vaultfile/internal/vault"
 	"github.com/spf13/cobra"
@@ -25,8 +23,11 @@ var (
 
 func Main(ctx context.Context, args []string, output io.Writer) error {
 	rootCmd := &cobra.Command{
-		Use:     "vaultfile",
-		Short:   "A CLI for encrypting and decrypting file content using the VaultFile format.",
+		Use:   "vaultfile",
+		Short: "Encrypt and decrypt content using pipes and the VaultFile format",
+		Long: `vaultfile is a command-line tool for encrypting and decrypting content using pipes.
+Input is read from stdin and output is written to stdout, making it easy to use
+in shell pipelines and scripts.`,
 		Version: BuildShortSHA,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			verbose, err := cmd.Flags().GetBool("verbose")
@@ -46,40 +47,40 @@ func Main(ctx context.Context, args []string, output io.Writer) error {
 	rootCmd.SilenceUsage = true
 	rootCmd.SilenceErrors = true
 
-	rootCmd.AddCommand(newCommand("decrypt", "decrypt content from a file", "vaultfile decrypt --input encrypted.vault --output decrypted.txt", decrypt))
-	rootCmd.AddCommand(newCommand("encrypt", "encrypt content from a file", "vaultfile encrypt --input plaintext.txt --output encrypted.vault", encrypt))
+	rootCmd.AddCommand(newCommand("decrypt", "Decrypt content from stdin to stdout", `cat encrypted.vault | vaultfile decrypt > plaintext.txt
+  vaultfile decrypt < encrypted.vault > plaintext.txt`, false, decrypt))
+	rootCmd.AddCommand(newCommand("encrypt", "Encrypt content from stdin to stdout", `cat plaintext.txt | vaultfile encrypt > encrypted.vault
+  echo "secret data" | vaultfile encrypt > encrypted.vault`, true, encrypt))
 
 	return rootCmd.ExecuteContext(ctx)
 }
 
-func newCommand(name string, short string, example string, runFn processFunc) *cobra.Command {
+func newCommand(name string, short string, example string, confirmPassword bool, runFn processFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     name,
 		Short:   short,
 		Example: example,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			input, err := cmd.Flags().GetString("input")
+			// TODO: respect context
+			inputBytes, err := io.ReadAll(cmd.InOrStdin())
 			if err != nil {
-				return fmt.Errorf("failed to get input flag: %w", err)
+				return fmt.Errorf("read input: %w", err)
 			}
 
-			output, err := cmd.Flags().GetString("output")
+			password, err := PromptPassword(os.Stderr, confirmPassword)
 			if err != nil {
-				return fmt.Errorf("failed to get input flag: %w", err)
+				return fmt.Errorf("read password: %w", err)
 			}
 
-			force, err := cmd.Flags().GetBool("force")
+			logger := slog.Default()
+			v, err := vault.New(vault.WithLogger(logger))
 			if err != nil {
-				return fmt.Errorf("failed to get input flag: %w", err)
+				return fmt.Errorf("create vault: %w", err)
 			}
 
-			return processContent(cmd.Context(), input, output, force, true, runFn)
+			return runFn(cmd.Context(), v, inputBytes, password, cmd.OutOrStdout())
 		},
 	}
-
-	cmd.Flags().StringP("input", "i", "", "Input `file`")
-	cmd.Flags().StringP("output", "o", "", "Output `file` (default: stdout)")
-	cmd.Flags().BoolP("force", "f", false, "Overwrite existing output file")
 
 	return cmd
 }
@@ -99,58 +100,9 @@ func setupLogging(verbose bool, output io.Writer) {
 
 type processFunc func(ctx context.Context, v *vault.Vault, input []byte, password []byte, output io.Writer) error
 
-func processContent(ctx context.Context, input string, output string, force bool, confirmPassword bool, pf processFunc) error {
-	// check if input file exists (if specified)
-	if input != "" {
-		if _, err := os.Stat(input); os.IsNotExist(err) {
-			return fmt.Errorf("input file does not exist: %s", input)
-		}
-	}
-
-	// check if we can write to output (if specified and not forcing)
-	if output != "" && !force {
-		if _, err := os.Stat(output); err == nil {
-			return fmt.Errorf("output file already exists: %s (use --force to overwrite)", output)
-		}
-	}
-
-	// validate that force is only used with output
-	if force && output == "" {
-		return errors.New("--force can only be used with --output")
-	}
-
-	inputBytes, err := readInput(input)
-	if err != nil {
-		return fmt.Errorf("failed to read input: %w", err)
-	}
-
-	password, err := PromptPassword(os.Stderr, confirmPassword)
-	if err != nil {
-		return fmt.Errorf("read password: %w", err)
-	}
-
-	logger := slog.Default()
-	v, err := vault.New(vault.WithLogger(logger))
-	if err != nil {
-		return fmt.Errorf("failed to create vault: %w", err)
-	}
-
-	w, close, err := openOutput(output, force)
-	if err != nil {
-		return fmt.Errorf("failed to open output: %w", err)
-	}
-	defer func() {
-		if err := close(); err != nil {
-			logger.ErrorContext(ctx, "failed to close file", slog.String("file", output))
-		}
-	}()
-
-	return pf(ctx, v, inputBytes, password, w)
-}
-
 func encrypt(ctx context.Context, v *vault.Vault, input []byte, password []byte, output io.Writer) error {
 	if err := v.Encrypt(ctx, output, password, input); err != nil {
-		return fmt.Errorf("encryption failed: %w", err)
+		return fmt.Errorf("encrypt: %w", err)
 	}
 	return nil
 }
@@ -158,41 +110,12 @@ func encrypt(ctx context.Context, v *vault.Vault, input []byte, password []byte,
 func decrypt(ctx context.Context, v *vault.Vault, input []byte, password []byte, output io.Writer) error {
 	plainText, err := v.Decrypt(ctx, bytes.NewReader(input), password)
 	if err != nil {
-		return fmt.Errorf("decryption failed: %w", err)
+		return fmt.Errorf("decrypt: %w", err)
 	}
 
 	if _, err := output.Write(plainText); err != nil {
-		return fmt.Errorf("failed to write output: %w", err)
+		return fmt.Errorf("write output: %w", err)
 	}
 
 	return nil
-}
-
-func readInput(path string) ([]byte, error) {
-	path = filepath.Clean(path)
-
-	if path == "" {
-		return nil, fmt.Errorf("input file is required")
-	}
-
-	return os.ReadFile(path)
-}
-
-func openOutput(path string, force bool) (io.Writer, func() error, error) {
-	path = filepath.Clean(path)
-
-	if path == "" {
-		return os.Stdout, func() error { return nil }, nil
-	}
-
-	if _, err := os.Stat(path); err == nil && !force {
-		return nil, nil, fmt.Errorf("output file %q already exists; use --force to overwrite", path)
-	}
-
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, defaultFilePermissions)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return f, func() error { return f.Close() }, nil
 }

--- a/cmd/vaultfile/root.go
+++ b/cmd/vaultfile/root.go
@@ -57,21 +57,21 @@ func newCommand(name string, short string, example string, confirmPassword bool,
 		Short:   short,
 		Example: example,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			logger := slog.Default()
+			v, err := vault.New(vault.WithLogger(logger))
+			if err != nil {
+				return fmt.Errorf("create vault: %w", err)
+			}
+
 			// TODO: respect context
 			inputBytes, err := io.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return fmt.Errorf("read input: %w", err)
 			}
 
-			password, err := PromptPassword(os.Stderr, confirmPassword)
+			password, err := PromptPassword(os.Stderr, confirmPassword, logger)
 			if err != nil {
 				return fmt.Errorf("read password: %w", err)
-			}
-
-			logger := slog.Default()
-			v, err := vault.New(vault.WithLogger(logger))
-			if err != nil {
-				return fmt.Errorf("create vault: %w", err)
 			}
 
 			return runFn(cmd.Context(), v, inputBytes, password, cmd.OutOrStdout())

--- a/cmd/vaultfile/root.go
+++ b/cmd/vaultfile/root.go
@@ -124,11 +124,10 @@ func processContent(ctx context.Context, input string, output string, force bool
 		return fmt.Errorf("failed to read input: %w", err)
 	}
 
-	password, err := PromptPassword(nil, os.Stderr, confirmPassword)
+	password, err := PromptPassword(os.Stderr, confirmPassword)
 	if err != nil {
-		return fmt.Errorf("failed to read password: %w", err)
+		return fmt.Errorf("read password: %w", err)
 	}
-	defer ZeroPassword(password)
 
 	logger := slog.Default()
 	v, err := vault.New(vault.WithLogger(logger))

--- a/cmd/vaultfile/root.go
+++ b/cmd/vaultfile/root.go
@@ -12,10 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	defaultFilePermissions = 0600
-)
-
 var (
 	BuildVersion  = `(missing)`
 	BuildShortSHA = `(missing)`


### PR DESCRIPTION
⚠️ **Breaking change**
Currently the CLI only supports encrypting and decrypting content by specifying the input and output file locations. This pattern does not lend itself well to building useful bash scripts because it does not support pipes.

To change this, we're simplifying the CLI by removing the `input` and `output` flags, automatically fetching input from `stdin` and outputting to `stdout`. This allows us to create pipelines such as:
```bash
tar czf - my-directory/ | vaultfile encrypt > backup.vault
```