### PR TITLE
Fix release tag workflow using the incorrect ref name

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   release:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
The main branch is master, not main - this meant the workflow was always skipped (e.g. https://github.com/HallyG/vaultfile/actions/runs/18080345780)